### PR TITLE
fix: enable release- and deploy-pipelines

### DIFF
--- a/.github/workflows/deploy-storybook.yml
+++ b/.github/workflows/deploy-storybook.yml
@@ -10,6 +10,10 @@ permissions:
   pages: write
   id-token: write
 
+concurrency:
+  group: deploy-storybook
+  cancel-in-progress: true
+
 jobs:
   deploy:
     name: "🚢 Deploy to GitHub Pages"

--- a/.github/workflows/quality-check.yaml
+++ b/.github/workflows/quality-check.yaml
@@ -2,7 +2,9 @@ name: "🛡️ Quality Check"
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened]
+    types: [ opened, synchronize, reopened ]
+  push:
+    branches: [ main ]
 
 jobs:
   lint:
@@ -26,7 +28,7 @@ jobs:
     name: "🧪 Test"
     runs-on: ubuntu-latest
     if: github.event.pull_request.draft == false
-    needs: [lint]
+    needs: [ lint ]
     steps:
       - name: "Checkout"
         uses: actions/checkout@v4

--- a/.github/workflows/release-lib.yaml
+++ b/.github/workflows/release-lib.yaml
@@ -2,8 +2,12 @@ name: "🚀 Release — Library"
 
 on:
   workflow_run:
-    workflows: ["🛡️ Quality Check"]
-    types: [completed]
+    workflows: [ "🌐 Deploy — Storybook" ]
+    types: [ completed ]
+
+concurrency:
+  group: release
+  cancel-in-progress: false
 
 jobs:
   release:


### PR DESCRIPTION
Run Pipelines on Push into main in this order:
🛡️ Quality Check → 🌐 Deploy Storybook → 🚀 Release Library