### PR TITLE
refactor: remove unused prop

### DIFF
--- a/src/components/button/button.tsx
+++ b/src/components/button/button.tsx
@@ -21,7 +21,7 @@ export const Button: React.FC<ButtonProps> = ({
     className={twMerge(
       buttonVariants({ variant, size }),
       fullWidth && "w-full",
-      isCircular && "rounded-full"
+      isCircular && "rounded-full",
     )}
   />
 );


### PR DESCRIPTION
The ButtonProps already includes ALL possible props for a native html button (including aria-label)

```
type ButtonProps = React.ComponentProps<"button"> &
  VariantProps<typeof buttonVariants> & {
    fullWidth?: boolean;
    isCircular?: boolean;
  };
```